### PR TITLE
New optimizer jpeg-archive / recompress

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Images should be kept on the highest quality settings to achieve best results.
 
 ```ini
 QUALITY = 100
+JPEGRECOMPRESS_PATH = '/usr/bin/jpeg-recompress'
 OPTIMIZERS = [
   'thumbor.optimizers.jpegtran'
 ]

--- a/README.md
+++ b/README.md
@@ -6,3 +6,41 @@
 pip install https://github.com/thumbor/thumbor-plugins/archive/master.zip
 ```
 
+## Usage
+
+### thumbor_plugins.optimizers.jpegrecompress
+
+This optimizer uses the tool [JPEG-Archive](https://github.com/danielgtaylor/jpeg-archive) to reduce the image size but keep the image visually the same. The process is lossy (**not** lossless) and similar to [JPEGmini](http://www.jpegmini.com/).
+
+> Compress JPEGs by re-encoding to the smallest JPEG quality while keeping perceived visual quality the same and by making sure huffman tables are optimized. This is a lossy operation, but the images are visually identical and it usually saves 30-70% of the size for JPEGs coming from a digital camera, particularly DSLRs. By default all EXIF/IPTC/XMP and color profile metadata is copied over, but this can be disabled to save more space if desired.
+
+Images should be kept on the highest quality settings to achieve best results.
+
+```ini
+QUALITY = 100
+OPTIMIZERS = [
+  'thumbor.optimizers.jpegtran'
+]
+```
+
+Result:
+```
+root@a08db5748d10:/data# thumbor /usr/local/bin/thumbor -p 9000 -c /etc/thumbor.conf -l debug
+2015-07-24 17:49:19 root:DEBUG thumbor running at 0.0.0.0:9000
+2015-07-24 17:49:21 thumbor:DEBUG STATSD: storage.hit:1|c
+2015-07-24 17:49:21 thumbor:DEBUG No image format specified. Retrieving from the image extension: .jpg.
+2015-07-24 17:49:21 thumbor:DEBUG Content Type of image/jpeg detected.
+2015-07-24 17:49:21 thumbor:DEBUG [JPEG-RECOMPRESS] running: /usr/bin/jpeg-recompress --strip --accurate --loops 10 /tmp/tmphFS4Uc /tmp/tmp__CwVY
+ssim at q=67 (40 - 95): 0.963943
+ssim at q=81 (68 - 95): 0.977207
+ssim at q=88 (82 - 95): 0.984416
+ssim at q=92 (89 - 95): 0.989077
+ssim at q=94 (93 - 95): 0.991773
+ssim at q=95 (95 - 95): 0.992719
+ssim at q=96 (96 - 95): 0.994757
+ssim at q=96 (97 - 95): 0.994757
+ssim at q=96 (97 - 95): 0.994757
+Final optimized ssim at q=96: 0.994763
+New size is 57% of original (saved 45 kb)
+2015-07-24 17:49:22 tornado.access:INFO 200 GET /unsafe/test.jpg (192.168.59.3) 1246.18ms
+```

--- a/thumbor_plugins/optimizers/jpegrecompress.py
+++ b/thumbor_plugins/optimizers/jpegrecompress.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+
+
+import os
+import subprocess
+
+from thumbor.optimizers import BaseOptimizer
+from thumbor.utils import logger
+
+
+class Optimizer(BaseOptimizer):
+    def __init__(self, context):
+        super(Optimizer, self).__init__(context)
+
+        self.runnable = True
+        self.jpegrecompress_path = self.context.config.JPEGRECOMPRESS_PATH
+
+        if not (os.path.isfile(self.jpegrecompress_path) and os.access(self.jpegrecompress_path, os.X_OK)):
+            logger.error("ERROR jpeg-recompress path '{0}' is not accessible".format(self.jpegrecompress_path))
+            self.runnable = False
+
+    def should_run(self, image_extension, buffer):
+        return ('jpg' in image_extension or 'jpeg' in image_extension) and self.runnable
+
+    def optimize(self, buffer, input_file, output_file):
+        command = '%s --no-copy --strip --accurate --loops 10 %s %s ' % (
+            self.jpegrecompress_path,
+            input_file,
+            output_file,
+        )
+        subprocess.call(command, shell=True, stdin=null)

--- a/thumbor_plugins/optimizers/jpegrecompress.py
+++ b/thumbor_plugins/optimizers/jpegrecompress.py
@@ -35,4 +35,6 @@ class Optimizer(BaseOptimizer):
             input_file,
             output_file,
         )
-        subprocess.call(command, shell=True, stdin=null)
+        with open(os.devnull) as null:
+            logger.debug("[JPEG-RECOMPRESS] running: " + command)
+            subprocess.call(command, shell=True, stdin=null)

--- a/thumbor_plugins/optimizers/jpegrecompress.py
+++ b/thumbor_plugins/optimizers/jpegrecompress.py
@@ -30,7 +30,7 @@ class Optimizer(BaseOptimizer):
         return ('jpg' in image_extension or 'jpeg' in image_extension) and self.runnable
 
     def optimize(self, buffer, input_file, output_file):
-        command = '%s --no-copy --strip --accurate --loops 10 %s %s ' % (
+        command = '%s --strip --accurate --loops 10 %s %s ' % (
             self.jpegrecompress_path,
             input_file,
             output_file,


### PR DESCRIPTION
> moved from thumbor/thumbor#512

It would be great if someone could help providing an optimiser integration for [jpeg-archive](https://github.com/danielgtaylor/jpeg-archive). I had great success reducing images without visible effects, e.g. similar to [jpegmini](http://www.jpegmini.com/). 

If you want to give it  a shot just clone and run it on a couple of images:
```
./jpeg-recompress --no-copy -s -a --loops 10 <source image> <target image>
```

Unfortunately I was unable to get thumbor running so that i could contribute code, e.g. PILEngine was missing even though it was in the path.

Enrico