### PR TITLE
Pngquant optimizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ install:
     - sudo make clean
 
     - sudo ldconfig /usr/lib
-    
+
     # install aptitude packages
-    - cd ~/build/thumbor/thumbor-plugins
+    - cd ~/build/okor/thumbor-plugins
     - LDFLAGS=-lm sudo aptitude install -y $(< requirements)
     - make setup
-    
+
     # installing mozjpeg before pillow (make setup) will create errors
     - cd ~
     - wget https://github.com/mozilla/mozjpeg/archive/v3.1.tar.gz
@@ -43,7 +43,7 @@ install:
     - cd build
     - sh ../configure --prefix=/usr/local
     - sudo make install
-    
-    - cd ~/build/thumbor/thumbor-plugins
+
+    - cd ~/build/okor/thumbor-plugins
 script:
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
     - sudo ldconfig /usr/lib
 
     # install aptitude packages
-    - cd ~/build/okor/thumbor-plugins
+    - cd ~/build/thumbor/thumbor-plugins
     - LDFLAGS=-lm sudo aptitude install -y $(< requirements)
     - make setup
 
@@ -51,6 +51,6 @@ install:
     - make
     - sudo make install
 
-    - cd ~/build/okor/thumbor-plugins
+    - cd ~/build/thumbor/thumbor-plugins
 script:
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - python: "pypy"
 install:
     - sudo apt-get update -y
-    - sudo apt-get -y install build-essential cmake libtool libwebp-dev unzip python-dev aptitude autoconf automake m4 nasm pkg-config
+    - sudo apt-get -y install build-essential cmake libtool libwebp-dev unzip python-dev aptitude autoconf automake m4 nasm pkg-config libpng-dev
     - pip install setuptools
 
     - cd ~
@@ -33,7 +33,7 @@ install:
     - LDFLAGS=-lm sudo aptitude install -y $(< requirements)
     - make setup
 
-    # installing mozjpeg before pillow (make setup) will create errors
+    # installing mozjpeg before pillow (make setup) or there will be errors
     - cd ~
     - wget https://github.com/mozilla/mozjpeg/archive/v3.1.tar.gz
     - tar xf v3.1.tar.gz
@@ -42,6 +42,13 @@ install:
     - mkdir build
     - cd build
     - sh ../configure --prefix=/usr/local
+    - sudo make install
+
+    - cd ~
+    - wget https://github.com/pornel/pngquant/archive/2.5.0.tar.gz
+    - tar xf 2.5.0.tar.gz
+    - cd pngquant-2.5.0
+    - make
     - sudo make install
 
     - cd ~/build/okor/thumbor-plugins

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -162,15 +162,3 @@ class PngquantOptimizerTest(unittest.TestCase):
 
         self.assertLessEqual(os.path.getsize(temp.name), os.path.getsize(fixtures_folder + '/img/bend.png'),
                              "pngquant could not lower filesize for img/bend.png")
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -22,6 +22,7 @@ from thumbor_plugins.optimizers.pngcrush import Optimizer as PngcrushOptimizer
 from thumbor_plugins.optimizers.optipng import Optimizer as OptipngOptimizer
 from thumbor_plugins.optimizers.jp2 import Optimizer as Jp2Optimizer
 from thumbor_plugins.optimizers.mozjpeg import Optimizer as MozjpegOptimizer
+from thumbor_plugins.optimizers.pngquant import Optimizer as PngquantOptimizer
 
 fixtures_folder = join(abspath(dirname(__file__)), 'fixtures')
 
@@ -137,7 +138,30 @@ class MozjpegOptimizerTest(unittest.TestCase):
         self.assertLessEqual(os.path.getsize(temp.name), os.path.getsize(fixtures_folder + '/img/bend.png'),
                              "mozjpeg could not lower filesize for img/bend.png")
 
+class PngquantOptimizerTest(unittest.TestCase):
+    def get_context(self):
+        conf = Config()
+        conf.STATSD_HOST = ''
+        ctx = Context(config=conf)
+        ctx.request = RequestParameters()
 
+        return ctx
+
+    def test_pngquant_should_not_run_for_jpeg(self):
+        optimizer = PngquantOptimizer(self.get_context())
+        self.assertFalse(optimizer.should_run('jpeg', None))
+
+    def test_pngquant_should_run_for_png(self):
+        optimizer = PngquantOptimizer(self.get_context())
+        self.assertTrue(optimizer.should_run('png', None))
+
+    def test_pngquant_should_optimize(self):
+        optimizer = PngquantOptimizer(self.get_context())
+        temp = tempfile.NamedTemporaryFile()
+        optimizer.optimize(None, fixtures_folder + '/img/bend.png', temp.name)
+
+        self.assertLessEqual(os.path.getsize(temp.name), os.path.getsize(fixtures_folder + '/img/bend.png'),
+                             "pngquant could not lower filesize for img/bend.png")
 
 
 

--- a/thumbor_plugins/optimizers/__init__.py
+++ b/thumbor_plugins/optimizers/__init__.py
@@ -55,3 +55,10 @@ Config.define(
     'Optimization level for pngquant ([0..100]-[0..100])',
     'Optimizers'
 )
+
+Config.define(
+    'PNGQUANT_SPEED',
+    '1',
+    'Optimization speed for pngquant 1-11, 1 is slowest',
+    'Optimizers'
+)

--- a/thumbor_plugins/optimizers/__init__.py
+++ b/thumbor_plugins/optimizers/__init__.py
@@ -51,7 +51,7 @@ Config.define(
 
 Config.define(
     'PNGQUANT_QUALITY',
-    '0-100',
+    '65-80',
     'Optimization level for pngquant ([0..100]-[0..100])',
     'Optimizers'
 )

--- a/thumbor_plugins/optimizers/__init__.py
+++ b/thumbor_plugins/optimizers/__init__.py
@@ -41,3 +41,17 @@ Config.define(
     'Optimization level for mozjpeg (0-100)',
     'Optimizers'
 )
+
+Config.define(
+    'PNGQUANT_PATH',
+    '/usr/local/bin/pngquant',
+    'Path for the pngquant binary',
+    'Optimizers'
+)
+
+Config.define(
+    'PNGQUANT_QUALITY',
+    '0-100',
+    'Optimization level for pngquant ([0..100]-[0..100])',
+    'Optimizers'
+)

--- a/thumbor_plugins/optimizers/mozjpeg.py
+++ b/thumbor_plugins/optimizers/mozjpeg.py
@@ -41,5 +41,5 @@ class Optimizer(BaseOptimizer):
             output_file,
         )
         with open(os.devnull) as null:
-            logger.debug("[OPTIPNG] running: " + command)
+            logger.debug("[MOZJPEG] running: " + command)
             subprocess.call(command, shell=True, stdin=null)

--- a/thumbor_plugins/optimizers/pngquant.py
+++ b/thumbor_plugins/optimizers/pngquant.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+
+
+import os
+import subprocess
+
+from thumbor.optimizers import BaseOptimizer
+from thumbor.utils import logger
+
+
+class Optimizer(BaseOptimizer):
+    def __init__(self, context):
+        super(Optimizer, self).__init__(context)
+
+        self.runnable = True
+        self.pngquant_path = self.context.config.PNGQUANT_PATH
+        self.pngquant_quality = self.context.config.PNGQUANT_QUALITY or '75'
+
+        if not (os.path.isfile(self.pngquant_path) and os.access(self.pngquant_path, os.X_OK)):
+            logger.error("ERROR pnqquant path '{0}' is not accessible".format(self.pngquant_path))
+            self.runnable = False
+
+    def should_run(self, image_extension, buffer):
+        return 'png' in image_extension and self.runnable
+
+    def optimize(self, buffer, input_file, output_file):
+        # command = '%s --speed 1 --quality=%s %s >| %s' % (
+        #     self.pngquant_path,
+        #     self.pngquant_quality,
+        #     input_file,
+        #     output_file
+        # )
+        command = 'cat %s | %s --speed 1 --quality=%s - > %s' % (
+            input_file,
+            self.pngquant_path,
+            self.pngquant_quality,
+            output_file,
+        )
+        with open(os.devnull) as null:
+            logger.debug("[PNGQUANT] running: " + command)
+            subprocess.call(command, shell=True, stdin=null)

--- a/thumbor_plugins/optimizers/pngquant.py
+++ b/thumbor_plugins/optimizers/pngquant.py
@@ -21,7 +21,7 @@ class Optimizer(BaseOptimizer):
 
         self.runnable = True
         self.pngquant_path = self.context.config.PNGQUANT_PATH
-        self.pngquant_quality = self.context.config.PNGQUANT_QUALITY or '75'
+        self.pngquant_quality = self.context.config.PNGQUANT_QUALITY or '65-80'
         self.pngquant_speed = self.context.config.PNGQUANT_SPEED or '3'
 
         if not (os.path.isfile(self.pngquant_path) and os.access(self.pngquant_path, os.X_OK)):
@@ -32,12 +32,6 @@ class Optimizer(BaseOptimizer):
         return 'png' in image_extension and self.runnable
 
     def optimize(self, buffer, input_file, output_file):
-        # command = '%s --speed 1 --quality=%s %s >| %s' % (
-        #     self.pngquant_path,
-        #     self.pngquant_quality,
-        #     input_file,
-        #     output_file
-        # )
         command = 'cat %s | %s --speed %s --quality=%s - > %s' % (
             input_file,
             self.pngquant_path,

--- a/thumbor_plugins/optimizers/pngquant.py
+++ b/thumbor_plugins/optimizers/pngquant.py
@@ -22,6 +22,7 @@ class Optimizer(BaseOptimizer):
         self.runnable = True
         self.pngquant_path = self.context.config.PNGQUANT_PATH
         self.pngquant_quality = self.context.config.PNGQUANT_QUALITY or '75'
+        self.pngquant_speed = self.context.config.PNGQUANT_SPEED or '3'
 
         if not (os.path.isfile(self.pngquant_path) and os.access(self.pngquant_path, os.X_OK)):
             logger.error("ERROR pnqquant path '{0}' is not accessible".format(self.pngquant_path))
@@ -37,9 +38,10 @@ class Optimizer(BaseOptimizer):
         #     input_file,
         #     output_file
         # )
-        command = 'cat %s | %s --speed 1 --quality=%s - > %s' % (
+        command = 'cat %s | %s --speed %s --quality=%s - > %s' % (
             input_file,
             self.pngquant_path,
+            self.pngquant_speed,
             self.pngquant_quality,
             output_file,
         )

--- a/vows/get_image_with_optimizer_vows.py
+++ b/vows/get_image_with_optimizer_vows.py
@@ -114,7 +114,7 @@ class GetImageWithJp2(BaseContext):
             expect(response.code).to_equal(200)
 
 @Vows.batch
-class GetImageWithJp2(BaseContext):
+class GetImageWithMozjpeg(BaseContext):
     def get_app(self):
         cfg = Config(SECURITY_KEY='ACME-SEC')
         cfg.LOADER = "thumbor.loaders.file_loader"

--- a/vows/get_image_with_optimizer_vows.py
+++ b/vows/get_image_with_optimizer_vows.py
@@ -32,7 +32,7 @@ class BaseContext(TornadoHTTPContext):
 class GetImageWithPngcrush(BaseContext):
     def get_app(self):
         cfg = Config(SECURITY_KEY='ACME-SEC', PNGCRUSH_PATH=which('pngcrush'))
-        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.LOADER = 'thumbor.loaders.file_loader'
         cfg.FILE_LOADER_ROOT_PATH = storage_path
         cfg.OPTIMIZERS = [
             'thumbor_plugins.optimizers.pngcrush',
@@ -61,7 +61,7 @@ class GetImageWithPngcrush(BaseContext):
 class GetImageWithOptipng(BaseContext):
     def get_app(self):
         cfg = Config(SECURITY_KEY='ACME-SEC', OPTIPNG_PATH=which('optipng'), OPTIPNG_LEVEL=1)
-        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.LOADER = 'thumbor.loaders.file_loader'
         cfg.FILE_LOADER_ROOT_PATH = storage_path
         cfg.OPTIMIZERS = [
             'thumbor_plugins.optimizers.optipng',
@@ -89,7 +89,7 @@ class GetImageWithOptipng(BaseContext):
 class GetImageWithJp2(BaseContext):
     def get_app(self):
         cfg = Config(SECURITY_KEY='ACME-SEC')
-        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.LOADER = 'thumbor.loaders.file_loader'
         cfg.FILE_LOADER_ROOT_PATH = storage_path
         cfg.OPTIMIZERS = [
             'thumbor_plugins.optimizers.jp2',
@@ -117,7 +117,7 @@ class GetImageWithJp2(BaseContext):
 class GetImageWithMozjpeg(BaseContext):
     def get_app(self):
         cfg = Config(SECURITY_KEY='ACME-SEC')
-        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.LOADER = 'thumbor.loaders.file_loader'
         cfg.FILE_LOADER_ROOT_PATH = storage_path
         cfg.OPTIMIZERS = [
             'thumbor_plugins.optimizers.mozjpeg',
@@ -145,7 +145,7 @@ class GetImageWithMozjpeg(BaseContext):
 class GetImageWithPngquant(BaseContext):
     def get_app(self):
         cfg = Config(SECURITY_KEY='ACME-SEC')
-        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.LOADER = 'thumbor.loaders.file_loader'
         cfg.FILE_LOADER_ROOT_PATH = storage_path
         cfg.OPTIMIZERS = [
             'thumbor_plugins.optimizers.pngquant',

--- a/vows/get_image_with_optimizer_vows.py
+++ b/vows/get_image_with_optimizer_vows.py
@@ -140,3 +140,31 @@ class GetImageWithMozjpeg(BaseContext):
 
         def should_be_ok(self, response):
             expect(response.code).to_equal(200)
+
+@Vows.batch
+class GetImageWithPngquant(BaseContext):
+    def get_app(self):
+        cfg = Config(SECURITY_KEY='ACME-SEC')
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = storage_path
+        cfg.OPTIMIZERS = [
+            'thumbor_plugins.optimizers.pngquant',
+        ]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(8889, 'localhost', 'thumbor.conf', None, 'info', None)
+        server.security_key = 'ACME-SEC'
+        ctx = Context(server, cfg, importer)
+        application = ThumborServiceApp(ctx)
+
+        self.engine = PILEngine(ctx)
+
+        return application
+
+    class ShouldBePngquant(BaseContext):
+        def topic(self):
+            return self.get('/unsafe/bend.jpg')
+
+        def should_be_ok(self, response):
+            expect(response.code).to_equal(200)


### PR DESCRIPTION
This PR adds a pngquant optimizer. Requires a pngquant binary (use pngquant 2.0+). All tests pass. Used it on a local version of Thumbor, definitely works.

- install the plugins: `cd <thumbor path> && pip install -I https://github.com/okor/thumbor-plugins/archive/pngquant.zip`
- add `thumbor_plugins.optimizers.pngquant` to the `OPTIMIZERS` array in the thumbor config
- specify the pngquant path as `PNGQUANT_PATH` in config
- optionally, tune `PNGQUANT_QUALITY` in config ([0..100]-[0..100])
- optionally, tune `PNGQUANT_SPEED` in config (1-11)