### PR TITLE
Light weight plugin to convert non-transparent PNGs to JPEGs

### DIFF
--- a/thumbor_plugins/optimizers/__init__.py
+++ b/thumbor_plugins/optimizers/__init__.py
@@ -69,3 +69,17 @@ Config.define(
     'Path for the imgmin binary',
     'Optimizers'
 )
+
+Config.define(
+    'AUTOJPEG_QUALITY',
+    '90',
+    'Quality level for autojpeg optimizer. Possible values: 0-100',
+    'Optmizers'
+)
+
+Config.define(
+    'AUTOJPEG_SUBSAMPLING',
+    '0',
+    'Quality level for autojpeg optimizer. Possible values: -1, 0, 1, 2. Keep original = -1, 4:4:4 = 0, 4:2:2 = 1, 4:1:1 = 2',
+    'Optmizers'
+)

--- a/thumbor_plugins/optimizers/autojpeg.py
+++ b/thumbor_plugins/optimizers/autojpeg.py
@@ -24,13 +24,16 @@ class Optimizer(BaseOptimizer):
         self.autojpeg_subsampling = int(self.context.config.AUTOJPEG_SUBSAMPLING)
 
     def should_run(self, image_extension, buffer):
-        run_possible = 'png' in image_extension
+        if not 'png' in image_extension:
+            return False;
+
         input_image = Image.open(BytesIO(buffer))
         extrema = input_image.getextrema()
         has_alpha = (len(extrema) > 3) and (extrema[3][0] < 255)
-        should_pass = input_image.mode == 'P' or has_alpha
+        if input_image.mode == 'P' or has_alpha:
+            return False;
 
-        return run_possible and not should_pass
+        return True;
 
     def optimize(self, buffer, input_file, output_file):
         return Image.open(input_file).save(output_file, 'JPEG', quality=self.autojpeg_quality, optimize=True, subsampling=self.autojpeg_subsampling)

--- a/thumbor_plugins/optimizers/autojpeg.py
+++ b/thumbor_plugins/optimizers/autojpeg.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+
+
+import os
+import subprocess
+
+from thumbor.optimizers import BaseOptimizer
+from thumbor.utils import logger
+from PIL import Image
+from io import BytesIO
+
+class Optimizer(BaseOptimizer):
+    def __init__(self, context):
+        super(Optimizer, self).__init__(context)
+
+        self.autojpeg_quality = int(self.context.config.AUTOJPEG_QUALITY)
+        self.autojpeg_subsampling = int(self.context.config.AUTOJPEG_SUBSAMPLING)
+
+    def should_run(self, image_extension, buffer):
+        run_possible = 'autojpeg' in self.context.request.filters and 'png' in image_extension
+        input_image = Image.open(BytesIO(buffer))
+        extrema = input_image.getextrema()
+        has_alpha = (len(extrema) > 3) and (extrema[3][0] < 255)
+        should_pass = input_image.mode == 'P' or has_alpha
+
+        return run_possible and not should_pass
+
+    def optimize(self, buffer, input_file, output_file):
+        return Image.open(input_file).save(output_file, 'JPEG', quality=self.autojpeg_quality, optimize=True, subsampling=self.autojpeg_subsampling)

--- a/thumbor_plugins/optimizers/autojpeg.py
+++ b/thumbor_plugins/optimizers/autojpeg.py
@@ -36,4 +36,9 @@ class Optimizer(BaseOptimizer):
         return True;
 
     def optimize(self, buffer, input_file, output_file):
-        return Image.open(input_file).save(output_file, 'JPEG', quality=self.autojpeg_quality, optimize=True, subsampling=self.autojpeg_subsampling)
+        source_image = Image.open(input_file)
+        if source_image.mode != 'RGB':
+            source_image = source_image.convert('RGB')
+
+        return source_image.save(output_file, 'JPEG', quality=self.autojpeg_quality, optimize=True, subsampling=self.autojpeg_subsampling)
+

--- a/thumbor_plugins/optimizers/autojpeg.py
+++ b/thumbor_plugins/optimizers/autojpeg.py
@@ -24,7 +24,7 @@ class Optimizer(BaseOptimizer):
         self.autojpeg_subsampling = int(self.context.config.AUTOJPEG_SUBSAMPLING)
 
     def should_run(self, image_extension, buffer):
-        run_possible = 'autojpeg' in self.context.request.filters and 'png' in image_extension
+        run_possible = 'png' in image_extension
         input_image = Image.open(BytesIO(buffer))
         extrema = input_image.getextrema()
         has_alpha = (len(extrema) > 3) and (extrema[3][0] < 255)

--- a/vows/get_image_with_optimizer_vows.py
+++ b/vows/get_image_with_optimizer_vows.py
@@ -196,3 +196,31 @@ class GetImageWithAuto(BaseContext):
 
         def should_be_ok(self, response):
             expect(response.code).to_equal(200)
+
+@Vows.batch
+class GetImageWithAutoJpeg(BaseContext):
+    def get_app(self):
+        cfg = Config(SECURITY_KEY='ACME-SEC')
+        cfg.LOADER = 'thumbor.loaders.file_loader'
+        cfg.FILE_LOADER_ROOT_PATH = storage_path
+        cfg.OPTIMIZERS = [
+            'thumbor_plugins.optimizers.autojpeg',
+        ]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(8889, 'localhost', 'thumbor.conf', None, 'info', None)
+        server.security_key = 'ACME-SEC'
+        ctx = Context(server, cfg, importer)
+        application = ThumborServiceApp(ctx)
+
+        self.engine = PILEngine(ctx)
+
+        return application
+
+    class ShouldBeAuto(BaseContext):
+        def topic(self):
+            return self.get('/unsafe/bend.png')
+
+        def should_be_ok(self, response):
+            expect(response.code).to_equal(200)

--- a/vows/get_image_with_optimizer_vows.py
+++ b/vows/get_image_with_optimizer_vows.py
@@ -218,7 +218,7 @@ class GetImageWithAutoJpeg(BaseContext):
 
         return application
 
-    class ShouldBeAuto(BaseContext):
+    class ShouldBeAutoJpeg(BaseContext):
         def topic(self):
             return self.get('/unsafe/bend.png')
 


### PR DESCRIPTION
### Functionality
This plugin will convert PNGs to JPEGs, if the input PNG does not have any transparent pixels.

### Reasoning
In my case, I see editorial folks uploading PNGs sometimes in an attempt to get higher quality output ... this doesn't really work because we use webp. But they still do it. This doesn't really matter on Chrome as webp output will be very similar size for JPEG or PNG input. But that means all other browsers actually get PNGs, which are huge. This prevents that scenario by smartly forcing JPEG output if the input PNG does not have any transparent pixels.

My older `auto` plugin did the same thing. But it relied on imgmin which was also horribly slow so it never made it to production. This just uses Pillow, so it's fast. But you still get the benefit of much smaller images. Imgmin used a brute force method to try to find the best quality (that's what made it slow). So autojpeg has the disadvantage that quality is not guaranteed, but that's how all other images work with a naive "quality" argument so this is on par with the rest of images that Thumbor produces.

Additionally, `AUTOJPEG_QUALITY` and `AUTOJPEG_SUBSAMPLING` config settings are completely independent from the normal `QUALITY` setting so you can tune the quality of the output. Users can tune this however they want.

### Usage
Simply install thumbor-plugins and activate in config:
```
OPTIMIZERS = [
    'thumbor_plugins.optimizers.autojpeg'
]
```
