### PR TITLE
remove temporary output file

### DIFF
--- a/thumbor_plugins/optimizers/optipng.py
+++ b/thumbor_plugins/optimizers/optipng.py
@@ -39,4 +39,5 @@ class Optimizer(BaseOptimizer):
         )
         with open(os.devnull) as null:
             logger.debug("[OPTIPNG] running: " + command)
+            os.unlink(output_file)
             subprocess.call(command, shell=True, stdin=null)


### PR DESCRIPTION
For each picture optipng optimizer always creates empty 'tmp(.*).bak' file in /tmp folder.  This cause problem with too many inodes on our production server. The cause of problem is parameter "-keep" in optipng, but without this optimizer don't work (optimizer leave empty temporary file). Removing temporary file before optipng commmand resolves this problem. 
