### PR TITLE
cleanup intermediary file for mozjpeg

### DIFF
--- a/thumbor_plugins/optimizers/mozjpeg.py
+++ b/thumbor_plugins/optimizers/mozjpeg.py
@@ -43,3 +43,4 @@ class Optimizer(BaseOptimizer):
         with open(os.devnull) as null:
             logger.debug("[MOZJPEG] running: " + command)
             subprocess.call(command, shell=True, stdin=null)
+            os.unlink(intermediary)


### PR DESCRIPTION
This especially useful on aws lambda deployments where shared function instances may run out of disk.