### PR TITLE
fix: Replace CC-BY-2.0 with CC-BY-4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ For example, the mozjpeg optimizer is released on the package
 ## Third Party
 
 Integration tests uses a bug.png picture by [Marcelo Jorge Vieira][marcelometal]
-licensed under [CC-BY][cc-by].
+licensed under [CC-BY-4.0][cc-by-4].
 
-[cc-by]: https://creativecommons.org/licenses/by/2.0/
+[cc-by-4]: https://creativecommons.org/licenses/by/4.0/
 [contributing]: https://github.com/thumbor/thumbor-plugins/blob/master/CONTRIBUTING.md
 [marcelometal]: https://www.flickr.com/photos/marcelometal/540719764/
 [thumbor]: https://github.com/thumbor/thumbor


### PR DESCRIPTION
DFSG-compatible License